### PR TITLE
Fixing license root uri

### DIFF
--- a/bin/dart_license_checker.dart
+++ b/bin/dart_license_checker.dart
@@ -75,7 +75,12 @@ void main(List<String> arguments) async {
 
     String rootUri = package['rootUri'];
     if (rootUri.startsWith('file://')) {
-      rootUri = rootUri.substring(8);
+      if (Platform.isWindows) {
+        rootUri = rootUri.substring(8);
+      }
+      else {
+        rootUri = rootUri.substring(7);
+      }
     }
 
     LicenseFile license;

--- a/bin/dart_license_checker.dart
+++ b/bin/dart_license_checker.dart
@@ -75,7 +75,7 @@ void main(List<String> arguments) async {
 
     String rootUri = package['rootUri'];
     if (rootUri.startsWith('file://')) {
-      rootUri = rootUri.substring(7);
+      rootUri = rootUri.substring(8);
     }
 
     LicenseFile license;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_license_checker
 description: Shows you which licenses your dependencies have.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/redsolver/dart_license_checker
 
 environment:


### PR DESCRIPTION
`rootUri` in `package['rootUri']` is starting with 3 `///` (Windows) now instead of 2.