### PR TITLE
v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.1
+
+- upgrade dependencies
+- use spdxIdentifier
+
 ## 1.2.0
 
 - Migrated to null safety

--- a/bin/dart_license_checker.dart
+++ b/bin/dart_license_checker.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:barbecue/barbecue.dart';
 import 'package:pana/pana.dart';
 import 'package:pana/src/license.dart';
 import 'package:path/path.dart';
-import 'package:barbecue/barbecue.dart';
 import 'package:tint/tint.dart';
 
 const possibleLicenseFileNames = [
@@ -83,7 +83,7 @@ void main(List<String> arguments) async {
       }
     }
 
-    LicenseFile? license;
+    List<License>? license;
 
     for (final fileName in possibleLicenseFileNames) {
       final file = File(join(rootUri, fileName));
@@ -94,10 +94,10 @@ void main(List<String> arguments) async {
       }
     }
 
-    if (license != null) {
+    if (license != null && license.isNotEmpty) {
       rows.add(Row(cells: [
         Cell(name, style: CellStyle(alignment: TextAlignment.TopRight)),
-        Cell(formatLicenseName(license)),
+        ...license.map((lic) => Cell(formatLicenseSpdx(lic)))
       ]));
     } else {
       rows.add(Row(cells: [
@@ -142,6 +142,20 @@ String formatLicenseName(LicenseFile license) {
     return license.shortFormatted.green();
   } else {
     return license.shortFormatted.yellow();
+  }
+}
+
+String formatLicenseSpdx(License license) {
+  if (license.spdxIdentifier == 'unknown') {
+    return license.spdxIdentifier.red();
+  } else if (copyleftOrProprietaryLicenses
+      .any((str) => str.contains(license.spdxIdentifier))) {
+    return license.spdxIdentifier.red();
+  } else if (permissiveLicenses
+      .any((str) => str.contains(license.spdxIdentifier))) {
+    return license.spdxIdentifier.green();
+  } else {
+    return license.spdxIdentifier.yellow();
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,7 +140,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.6.0"
   logging:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   meta:
     dependency: transitive
     description:
@@ -175,14 +175,14 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.21.7"
+    version: "0.21.14"
   path:
     dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pedantic:
     dependency: "direct dev"
     description:
@@ -282,4 +282,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,20 @@
 name: dart_license_checker
 description: Tool to view all dependencies (packages and plugins) you use and their licenses
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/redsolver/dart_license_checker
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  path: ^1.7.0
+  path: ^1.8.2
   tint: ^2.0.0
-  pana: ^0.21.7
+  pana: ^0.21.14
   pubspec_parse: ^1.2.0
   barbecue: ^0.4.0
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  pedantic: ^1.11.1
 
 executables:
   dart_license_checker: dart_license_checker


### PR DESCRIPTION
As mentioned in https://github.com/redsolver/dart_license_checker/issues/5
dart_license_checker can't be activated/build atm.

This would
- updated all dependencies
- use pana License spdxIdentifier
- bump version to 1.2.1